### PR TITLE
ability to compile to wasm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script: |
   # cargo install wasm-pack
   # wasm-pack init 
 script: |
+  rustup target add wasm32-unknown-unknown
+  cargo check --target wasm32-unknown-unknown
   cargo fmt --all -- --check &&
   cargo clippy -- -D all &&
   cargo build --verbose &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_script: |
   # wasm-pack init 
 script: |
   rustup target add wasm32-unknown-unknown
-  cargo check --target wasm32-unknown-unknown
   cargo fmt --all -- --check &&
   cargo clippy -- -D all &&
   cargo build --verbose &&
-  cargo test  --verbose
+  cargo test  --verbose &&
+  cargo check --target wasm32-unknown-unknown
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,8 @@ failure = "0.1.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-bson = "0.12.2"
-mongodb = "0.3.10"
+bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-suport" } 
 
 [dependencies.wasm-bindgen]
 version = "^0.2"
 features = ["serde-serialize"]
-
-[dev-dependencies]
-bson = "0.12.1"
-mongodb = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,17 @@ authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 readme = "README.md"
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 failure = "0.1.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-suport" } 
+wee_alloc = "0.4.2"
+console_error_panic_hook = "0.1.5"
 
 [dependencies.wasm-bindgen]
 version = "^0.2"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 [![crates.io version][1]][2] [![build status][3]][4]
 [![downloads][5]][6] [![docs.rs docs][7]][8]
 
-MongoDB Schema Parser.
+MongoDB Schema Parser. This library is meant to be used in Rust or as Web
+Assembly module in JavaScript.
 
 - [Documentation][8]
 - [Crates.io][2]
 
-## Usage
+## Usage: in Rust
 ```rust
 use SchemaParser
 
@@ -20,6 +21,30 @@ pub fn main () {
   }
   let result = schema_parser.to_json();
 }
+```
+
+## Usage: in JavaScript 
+Make sure your environment is setup for Web Assembly usage. 
+```js
+import { SchemaParser } from "mongodb-schema-parser";
+
+const schemaParser = new SchemaParser()
+
+// get the json file
+fetch('./fanclub.json')
+  .then(response => response.text())
+  .then(data => {
+    var json = data.split("\n")
+    for (var i = 0; i < json.length; i++) {
+      if (json[i] !== '') {
+        // feed the parser json line by line
+        schemaParser.write(json[i])
+      }
+    }
+    // get the result as a json string
+    var result = schemaParser.toJson()
+    console.log(result)
+  })
 ```
 
 ## Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@ use crate::field_type::FieldType;
 mod value_type;
 use crate::value_type::ValueType;
 
-// i have a method that returns a result with boxed error which i can't add the wasm-bindgen tag to them. intead i am wrapping my methods
-
 extern crate failure;
 
 #[wasm_bindgen]
@@ -45,6 +43,9 @@ pub struct SchemaParser {
   fields: Vec<Field>,
 }
 
+// Need to wrap schema parser impl for wasm suppport.
+// Here we are wrapping the exported to JS land methods and mathing on Result to
+// turn the error message to JsValue.
 #[wasm_bindgen]
 impl SchemaParser {
   #[wasm_bindgen(constructor)]

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,54 +1,56 @@
-use failure::Error;
-use mongodb_schema_parser::SchemaParser;
-use std::fs;
-
-#[test]
-fn simple_schema_gen() -> Result<(), Error> {
-  let doc = r#"{
-    "_id": {
-      "$oid": "50319491fe4dce143835c552"
-    },
-    "membership_status": "ACTIVE",
-    "name": "Ellie J Clarke",
-    "gender": "male",
-    "age": 36,
-    "phone_no": "+19786213180",
-    "last_login": {
-      "$date": "2014-01-31T22:26:33.000Z"
-    },
-    "address": {
-      "city": "El Paso, Texas",
-      "street": "133 Aloha Ave",
-      "postal_code": 50017,
-      "country": "USA",
-      "location": {
-        "type": "Point",
-        "coordinates":[-73.4446279457308,40.89674015263909]
-      }
-    },
-    "favorite_feature": "Auth",
-    "email": "corefinder88@hotmail.com"
-  }"#;
-
-  let mut schema_parser = SchemaParser::new();
-  schema_parser.write(doc)?;
-
-  let schema = schema_parser.to_json();
-  println!("{:?}", schema);
-  Ok(())
-}
-
-#[test]
-fn json_file_gen() -> Result<(), Error> {
-  // TODO: check timing on running this test
-  let file = fs::read_to_string("examples/fanclub.json")?;
-  let vec: Vec<&str> = file.trim().split('\n').collect();
-  let mut schema_parser = SchemaParser::new();
-  for json in vec {
-    // this panics i think ?
-    schema_parser.write(&json)?;
-  }
-  let schema = schema_parser.to_json();
-  println!("{:?}", schema);
-  Ok(())
-}
+// these set of tests cannot run with cdylib in cargo.toml
+// use failure::Error;
+// use mongodb_schema_parser::SchemaParser;
+// use std::fs;
+//
+// #[test]
+// fn simple_schema_gen() -> Result<(), Error> {
+//   let doc = r#"{
+//     "_id": {
+//       "$oid": "50319491fe4dce143835c552"
+//     },
+//     "membership_status": "ACTIVE",
+//     "name": "Ellie J Clarke",
+//     "gender": "male",
+//     "age": 36,
+//     "phone_no": "+19786213180",
+//     "last_login": {
+//       "$date": "2014-01-31T22:26:33.000Z"
+//     },
+//     "address": {
+//       "city": "El Paso, Texas",
+//       "street": "133 Aloha Ave",
+//       "postal_code": 50017,
+//       "country": "USA",
+//       "location": {
+//         "type": "Point",
+//         "coordinates":[-73.4446279457308,40.89674015263909]
+//       }
+//     },
+//     "favorite_feature": "Auth",
+//     "email": "corefinder88@hotmail.com"
+//   }"#;
+//
+//   let mut schema_parser = SchemaParser::new();
+//   schema_parser.write(doc)?;
+//
+//   let schema = schema_parser.to_json();
+//   println!("{:?}", schema);
+//   Ok(())
+// }
+//
+// #[test]
+// fn json_file_gen() -> Result<(), Error> {
+//   // TODO: check timing on running this test
+//   let file = fs::read_to_string("examples/fanclub.json")?;
+//   let vec: Vec<&str> = file.trim().split('\n').collect();
+//   let mut schema_parser = SchemaParser::new();
+//   for json in vec {
+//     // this panics i think ?
+//     schema_parser.write(&json)?;
+//   }
+//   let schema = schema_parser.to_json();
+//   println!("{:?}", schema);
+//   Ok(())
+// }
+//


### PR DESCRIPTION
To be able to compile to wasm with the current API, we need to wrap the methods we want in JS and format the Error string to `JsValue`. This adds a bit of overhead, but hopefully in the future we can have [something that's more JsError like](https://github.com/rustwasm/wasm-bindgen/issues/1017).

This PR also adds:
- [x] travis check for wasm compilation
- [x] bson-rs package points to my fork until we are all good to merge the [outstanding PR in bson-rs](https://github.com/zonyitoo/bson-rs/pull/111)
- [x] comments out the integration tests (need to look into using own crate when cargo.toml is set as `cdylib`. 
- [x] adds docs to the readme for the JS-exposed API