### PR TITLE
add docs to pub methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![crates.io version][1]][2] [![build status][3]][4]
 [![downloads][5]][6] [![docs.rs docs][7]][8]
 
-MongoDB Schema Parser. This library is meant to be used in Rust or as Web
-Assembly module in JavaScript.
+Infer a probabilistic schema for a MongoDB collection. This library is meant
+to be used in Rust or as Web Assembly module in JavaScript.
 
 - [Documentation][8]
 - [Crates.io][2]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,47 @@
+//! #Infer a probabilistic schema for a MongoDB collection.
+//! This crate creates a probabilistic scehma given a json-style string
+//! representing a MongoDB collection. It can be used in both rust and javascript
+//! given a WASM compilation.
+//!
+//! ## Usage: in Rust
+//! ```rust
+//! use SchemaParser
+//!
+//! pub fn main () {
+//!   let mut file = fs::read_to_string("examples/fanclub.json").unwrap();
+//!   let file: Vec<&str> = file.split("\n").collect();
+//!   let schema_parser = SchemaParser::new();
+//!   for json in file {
+//!     schema_parser.write(&json)?;
+//!   }
+//!   let result = schema_parser.to_json();
+//! }
+//! ```
+//!
+//! ## Usage: in JavaScript
+//! Make sure your environment is setup for Web Assembly usage.
+//! ```js
+//! import { SchemaParser } from "mongodb-schema-parser";
+//!
+//! const schemaParser = new SchemaParser()
+//!
+//! // get the json file
+//! fetch('./fanclub.json')
+//!   .then(response => response.text())
+//!   .then(data => {
+//!     var json = data.split("\n")
+//!     for (var i = 0; i < json.length; i++) {
+//!       if (json[i] !== '') {
+//!         // feed the parser json line by line
+//!         schemaParser.write(json[i])
+//!       }
+//!     }
+//!     // get the result as a json string
+//!     var result = schemaParser.toJson()
+//!     console.log(result)
+//!   })
+//! ```
+
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
@@ -72,6 +116,14 @@ impl SchemaParser {
 }
 
 impl SchemaParser {
+  /// Returns a new instance of Schema Parser populated with zero `count` and an
+  /// empty `fields` vector.
+  ///
+  /// # Examples
+  /// ```
+  /// use mongodb_schema_parser::SchemaParser;
+  /// let schema_parser = SchemaParser::new();
+  /// ```
   #[inline]
   pub fn new() -> Self {
     SchemaParser {
@@ -80,6 +132,18 @@ impl SchemaParser {
     }
   }
 
+  /// Writes json-like string slices SchemaParser's fields vector.
+  ///
+  /// # Arguments
+  /// * `json` - A json-like string slice. i.e { "name": "Nori", "type": "Cat"}
+  ///
+  /// # Examples
+  /// ```
+  /// use mongodb_schema_parser::SchemaParser;
+  /// let schema_parser = SchemaParser::new();
+  /// let json = "{ "name": "Chashu", "type": "Cat" }";
+  /// schema_parser.write(&json);
+  /// ```
   #[inline]
   pub fn write(
     &mut self,
@@ -95,6 +159,18 @@ impl SchemaParser {
     Ok(())
   }
 
+  /// Returns a serde_json string. This should be called after all values were
+  /// written. This is also the result of the parsed documents.
+  ///
+  /// # Examples
+  /// ```
+  /// use mongodb_schema_parser::SchemaParser;
+  /// let schema_parser = SchemaParser::new();
+  /// let json = "{ "name": "Chashu", "type": "Cat" }";
+  /// schema_parser.write(&json);
+  /// let schema = schema_parser.to_json().unwrap();
+  /// println!("{}")
+  /// ```
   #[inline]
   pub fn to_json(
     &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,12 +92,16 @@ pub struct SchemaParser {
 // turn the error message to JsValue.
 #[wasm_bindgen]
 impl SchemaParser {
+  /// Wrapper method for `SchemaParser::new()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "new")`
   #[wasm_bindgen(constructor)]
   #[wasm_bindgen(js_name = "new")]
   pub fn wasm_new() -> Self {
     Self::new()
   }
 
+  /// Wrapper method for `schema_parser.write()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "write")`
   #[wasm_bindgen(js_name = "write")]
   pub fn wasm_write(&mut self, json: &str) -> Result<(), JsValue> {
     match self.write(json) {
@@ -106,6 +110,8 @@ impl SchemaParser {
     }
   }
 
+  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "toJson")`
   #[wasm_bindgen(js_name = "toJson")]
   pub fn wasm_to_json(&mut self) -> Result<String, JsValue> {
     match self.to_json() {
@@ -242,7 +248,7 @@ impl SchemaParser {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+  // use super::*;
 
   #[test]
   fn it_creates_new() {}


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is added

## Context
Adds missing docs to the three public methods: `new`, `write` and `to_json`. Also adds the overall usage examples to the future docs.rs page.

## Semver Changes
n/a
