### PR TITLE
Fix adding nested vals

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -12,9 +12,9 @@ pub struct Field {
 }
 
 impl Field {
-  pub fn new(name: &str, path: &str, count: usize) -> Self {
+  pub fn new(name: String, path: &str, count: usize) -> Self {
     Field {
-      name: name.to_string(),
+      name: name,
       count,
       path: path.to_string(),
       field_type: None,
@@ -54,29 +54,27 @@ mod tests {
 
   #[test]
   fn it_creates_new() {
-    let name = "Nori";
     let path = "Nori.cat";
     let count = 1;
 
-    let field = Field::new(&name, &path, count);
+    let field = Field::new("Nori".to_string(), &path, count);
 
-    assert_eq!(field.name, name);
+    assert_eq!(field.name, "Nori".to_string());
     assert_eq!(field.path, path);
     assert_eq!(field.count, count);
   }
 
   #[bench]
   fn bench_it_creates_new(bench: &mut Bencher) {
-    let name = "Nori";
     let path = "Nori.cat";
     let count = 1;
 
-    bench.iter(|| Field::new(&name, &path, count));
+    bench.iter(|| Field::new("Nori".to_string(), &path, count));
   }
 
   #[test]
   fn it_adds_to_types() {
-    let mut field = Field::new("Chashu", "Chashu.cat", 1);
+    let mut field = Field::new("Chashu".to_string(), "Chashu.cat", 1);
     let field_type = FieldType::new("path");
     field.add_to_types(Some(field_type.clone()));
     assert_eq!(field.types[0], field_type);
@@ -84,7 +82,7 @@ mod tests {
 
   #[bench]
   fn bench_it_adds_to_types(bench: &mut Bencher) {
-    let mut field = Field::new("Chashu", "Chashu.cat", 1);
+    let mut field = Field::new("Chashu".to_string(), "Chashu.cat", 1);
 
     bench.iter(|| {
       let field_type = FieldType::new("path");
@@ -120,14 +118,14 @@ mod tests {
 
   #[test]
   fn it_sets_duplicates() {
-    let mut field = Field::new("Rey", "Rey.dog", 1);
+    let mut field = Field::new("Rey".to_string(), "Rey.dog", 1);
     field.set_duplicates(true);
     assert_eq!(field.has_duplicates, true)
   }
 
   #[bench]
   fn bench_it_sets_duplicates(bench: &mut Bencher) {
-    let mut field = Field::new("Rey", "Rey.dog", 1);
+    let mut field = Field::new("Rey".to_string(), "Rey.dog", 1);
     bench.iter(|| field.set_duplicates(true))
   }
 }

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -65,8 +65,9 @@ impl FieldType {
   pub fn get_value(value: &Bson) -> Option<ValueType> {
     match value {
       Bson::FloatingPoint(num) => Some(ValueType::FloatingPoint(*num)),
-      Bson::Boolean(boolean) => Some(ValueType::Boolean(*boolean)),
       Bson::String(string) => Some(ValueType::Str(string.to_string())),
+      Bson::Boolean(boolean) => Some(ValueType::Boolean(*boolean)),
+      Bson::ObjectId(id) => Some(ValueType::Str(id.to_string())),
       Bson::I32(num) => Some(ValueType::I32(*num)),
       Bson::I64(num) => Some(ValueType::I64(*num)),
       _ => None,
@@ -79,6 +80,7 @@ impl FieldType {
         Some(String::from("Number"))
       }
       Bson::Document(_) => Some(String::from("Document")),
+      Bson::ObjectId(_) => Some(String::from("ObjectId")),
       Bson::Boolean(_) => Some(String::from("Boolean")),
       Bson::String(_) => Some(String::from("String")),
       Bson::Array(_) => Some(String::from("Array")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl SchemaParser {
   }
 
   #[inline]
-  fn update_field(&mut self, key: &str, value: &Bson) {
+  fn update_field(&mut self, key: String, value: &Bson) {
     // need to set count here as well
     // maybe store the names in a hash map so then it's easier to look up the key
     for field in &mut self.fields {
@@ -304,10 +304,10 @@ mod tests {
     let mut schema_parser = SchemaParser::new();
     assert_eq!(schema_parser.fields.len(), 0);
 
-    let name = "Nori";
+    let name = "Nori".to_string();
     let path = "Nori.cat";
     let count = 1;
-    let field = Field::new(&name, &path, count);
+    let field = Field::new(name, &path, count);
 
     schema_parser.add_to_fields(field);
     assert_eq!(schema_parser.fields.len(), 1);
@@ -316,12 +316,11 @@ mod tests {
   #[bench]
   fn bench_it_adds_to_fields(bench: &mut Bencher) {
     let mut schema_parser = SchemaParser::new();
-    let name = "Nori";
     let path = "Nori.cat";
     let count = 1;
 
     bench.iter(|| {
-      let field = Field::new(&name, &path, count);
+      let field = Field::new("Nori".to_string(), &path, count);
       let n = test::black_box(field);
       schema_parser.add_to_fields(n)
     });
@@ -351,7 +350,7 @@ mod tests {
     let json_str = r#"{"name": "Chashu", "type": "Cat"}"#;
     schema_parser.write(&json_str).unwrap();
     let name = Bson::String("Nori".to_owned());
-    schema_parser.update_field("name", &name);
+    schema_parser.update_field("name".to_string(), &name);
     let vec = vec![
       ValueType::Str("Chashu".to_owned()),
       ValueType::Str("Nori".to_owned()),
@@ -366,7 +365,7 @@ mod tests {
     schema_parser.write(&json_str).unwrap();
     let name = Bson::String("Chashu".to_owned());
 
-    bench.iter(|| schema_parser.update_field("name", &name));
+    bench.iter(|| schema_parser.update_field("name".to_string(), &name));
   }
 
   #[test]

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -49,6 +49,6 @@ fn json_file_gen() -> Result<(), Error> {
     schema_parser.write(&json)?;
   }
   let schema = schema_parser.to_json();
-  println!("{:?}", schema.unwrap());
+  println!("{:?}", schema);
   Ok(())
 }


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
To make sure all nested documents get the correct values recursively, check for whether it's `Bson::Document` first in  `generate_fields` function. Also add a check for `Bson::ObjectId`

