### PR TITLE
array values, nested documents, multiple types per field

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -17,9 +17,6 @@ impl Field {
       name: name,
       count: 1,
       path: path.to_string(),
-      // if vector is empty at the end, serde-json should remove
-      // once a new type is added in lib to Field.types, should update this
-      // vector.
       bson_types: Vec::new(),
       probability: 0.0,
       has_duplicates: false,

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,4 +1,4 @@
-use super::FieldType;
+use super::{Bson, FieldType};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Field {
@@ -24,10 +24,25 @@ impl Field {
     }
   }
 
+  pub fn create_type(&mut self, value: &Bson) {
+    // let value_type = FieldType::get_type(&value);
+    let field_type = FieldType::new(&self.path).add_to_type(&value);
+    self.add_to_types(field_type.to_owned())
+  }
+
   pub fn add_to_types(&mut self, field_type: Option<FieldType>) {
     if let Some(field_type) = field_type {
       self.types.push(field_type)
     }
+  }
+
+  pub fn does_field_type_exist(&mut self, field_type: Option<String>) -> bool {
+    for ftype in &mut self.types {
+      if ftype.bsonType == field_type {
+        return true;
+      }
+    }
+    false
   }
 
   pub fn get_path(name: String, path: &Option<String>) -> String {

--- a/src/field.rs
+++ b/src/field.rs
@@ -17,6 +17,10 @@ impl Field {
       name: name,
       count: 1,
       path: path.to_string(),
+      // field_type should be set as a vector.
+      // if vector is empty at the end, serde-json should remove
+      // once a new type is added in lib to Field.types, should update this
+      // vector.
       field_type: None,
       probability: 0.0,
       has_duplicates: false,

--- a/src/field.rs
+++ b/src/field.rs
@@ -30,7 +30,7 @@ impl Field {
 
   pub fn create_type(&mut self, value: &Bson) {
     // let value_type = FieldType::get_type(&value);
-    let field_type = FieldType::new(&self.path).add_to_type(&value);
+    let field_type = FieldType::new(&self.path).add_to_type(&value, self.count);
     self.add_to_types(field_type.to_owned())
   }
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -34,10 +34,15 @@ impl FieldType {
     }
   }
 
-  pub fn add_to_type(mut self, value: &Bson) -> Option<Self> {
+  pub fn add_to_type(
+    mut self,
+    value: &Bson,
+    parent_count: usize,
+  ) -> Option<Self> {
     let bson_value = value.clone();
     self.set_name(&bson_value);
     self.set_bson_type(&bson_value);
+    self.set_probability(parent_count);
 
     match value {
       Bson::Array(arr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
     let json_str = r#"{"name": "Chashu", "type": "Cat"}"#;
     schema_parser.write(&json_str).unwrap();
     let output = schema_parser.to_json().unwrap();
-    assert_eq!(output, "{\"count\":1,\"fields\":[{\"name\":\"name\",\"path\":\"name\",\"count\":1,\"field_type\":null,\"probability\":0.0,\"has_duplicates\":false,\"types\":[{\"name\":\"String\",\"path\":\"name\",\"count\":1,\"bsonType\":\"String\",\"probability\":0.0,\"values\":[\"Chashu\"],\"has_duplicates\":false,\"unique\":null}]},{\"name\":\"type\",\"path\":\"type\",\"count\":1,\"field_type\":null,\"probability\":0.0,\"has_duplicates\":false,\"types\":[{\"name\":\"String\",\"path\":\"type\",\"count\":1,\"bsonType\":\"String\",\"probability\":0.0,\"values\":[\"Cat\"],\"has_duplicates\":false,\"unique\":null}]}]}");
+    assert_eq!(output, "{\"count\":1,\"fields\":[{\"name\":\"name\",\"path\":\"name\",\"count\":1,\"bson_types\":[\"String\"],\"probability\":0.0,\"has_duplicates\":false,\"types\":[{\"name\":\"String\",\"path\":\"name\",\"count\":1,\"bsonType\":\"String\",\"probability\":1.0,\"values\":[\"Chashu\"],\"has_duplicates\":false,\"schema\":null,\"unique\":null}]},{\"name\":\"type\",\"path\":\"type\",\"count\":1,\"bson_types\":[\"String\"],\"probability\":0.0,\"has_duplicates\":false,\"types\":[{\"name\":\"String\",\"path\":\"type\",\"count\":1,\"bsonType\":\"String\",\"probability\":1.0,\"values\":[\"Cat\"],\"has_duplicates\":false,\"schema\":null,\"unique\":null}]}]}");
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ use crate::value_type::ValueType;
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SchemaParser {
-  count: usize,
-  fields: Vec<Field>,
+  pub count: usize,
+  pub fields: Vec<Field>,
 }
 
 // Need to wrap schema parser impl for wasm suppport.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,14 +229,11 @@ impl SchemaParser {
         field.update_count();
         if !field.does_field_type_exist(FieldType::get_type(&value)) {
           // field type doesn't exist in field.types, create a new field_type
-          println!("field type does not exist {}", &key);
           field.create_type(&value);
         } else {
           // update field_type based on bson_type
           for field_type in &mut field.types {
             if field_type.bsonType == FieldType::get_type(&value) {
-              println!("updating field_type {}", &key);
-              println!("bson type of value {:?}", FieldType::get_type(&value));
               field_type.update_type(field.count, &value);
               has_duplicates = field_type.get_duplicates();
             }
@@ -253,7 +250,6 @@ impl SchemaParser {
     // check if we already have a field for this key;
     // if name exist, call self.update_field, otherwise create new
     if self.does_field_name_exist(&key) {
-      println!("field name exists {}", &key);
       self.update_field(&key, &value);
     } else {
       let mut field = Field::new(key, &path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ impl SchemaParser {
       if field.name == key {
         let mut has_duplicates = false;
         field.update_count();
-        if !field.does_field_type_exist(FieldType::get_type(&value)) {
+        if !field.does_field_type_exist(&FieldType::get_type(&value)) {
           // field type doesn't exist in field.types, create a new field_type
           field.create_type(&value);
         } else {

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -2,40 +2,88 @@ use failure::Error;
 use mongodb_schema_parser::SchemaParser;
 use std::fs;
 
+static DOC: &str = r#"{
+  "_id": {
+    "$oid": "50319491fe4dce143835c552"
+  },
+  "membership_status": "ACTIVE",
+  "name": "Ellie J Clarke",
+  "gender": "male",
+  "age": 36,
+  "phone_no": "+19786213180",
+  "last_login": {
+    "$date": "2014-01-31T22:26:33.000Z"
+  },
+  "address": {
+    "city": "El Paso, Texas",
+    "street": "133 Aloha Ave",
+    "postal_code": 50017,
+    "country": "USA",
+    "location": {
+      "type": "Point",
+      "coordinates":[-73.4446279457308,40.89674015263909]
+    }
+  },
+  "favorite_feature": "Auth",
+  "email": "corefinder88@hotmail.com"
+}"#;
+
+// static DOC2: &str = r#"{
+//   "_id": {
+//     "$oid": "50370aaefe4dce143735c679"
+//   },
+//   "membership_status": "INACTIVE",
+//   "name": "Logan Phillips",
+//   "gender": "male",
+//   "age": 23,
+//   "phone_no": 1272641335,
+//   "last_login": {
+//     "$date": "2011-02-16T02:11:10.000Z"
+//   },
+//   "address": {
+//     "city": "Oklahoma City, Oklahoma",
+//     "street": "276 Crescent Lake Rd",
+//     "postal_code": "48963",
+//     "country": "USA",
+//     "location": {
+//       "type": "Point",
+//       "coordinates": [-97.47815616033876, 35.41129245670654]
+//     }
+//   },
+//   "favorite_feature": "Aggregation",
+//   "email": "takeaway34@verizon.net"
+// }"#;
+
 #[test]
-fn simple_schema_gen() -> Result<(), Error> {
-  let doc = r#"{
-    "_id": {
-      "$oid": "50319491fe4dce143835c552"
-    },
-    "membership_status": "ACTIVE",
-    "name": "Ellie J Clarke",
-    "gender": "male",
-    "age": 36,
-    "phone_no": "+19786213180",
-    "last_login": {
-      "$date": "2014-01-31T22:26:33.000Z"
-    },
-    "address": {
-      "city": "El Paso, Texas",
-      "street": "133 Aloha Ave",
-      "postal_code": 50017,
-      "country": "USA",
-      "location": {
-        "type": "Point",
-        "coordinates":[-73.4446279457308,40.89674015263909]
-      }
-    },
-    "favorite_feature": "Auth",
-    "email": "corefinder88@hotmail.com"
-  }"#;
-
+fn it_creates_correct_number_of_fields() {
   let mut schema_parser = SchemaParser::new();
-  schema_parser.write(doc)?;
+  schema_parser.write(DOC).unwrap();
+  assert_eq!(schema_parser.fields.len(), 10);
+}
 
-  let schema = schema_parser.to_json();
-  println!("{:?}", schema);
-  Ok(())
+#[test]
+fn it_combines_arrays_for_same_field_into_same_types_vector() {
+  let mut schema_parser = SchemaParser::new();
+  let vec_json1 = r#"{"animals": ["cat", "dog"]}"#;
+  let vec_json2 = r#"{"animals": ["wallaby", "bird"]}"#;
+  schema_parser.write(vec_json1).unwrap();
+  schema_parser.write(vec_json2).unwrap();
+  assert_eq!(schema_parser.fields.len(), 1);
+  assert_eq!(schema_parser.fields[0].types.len(), 1);
+  assert_eq!(schema_parser.fields[0].types[0].values.len(), 4);
+}
+
+#[test]
+fn it_creates_different_field_types() {
+  let mut schema_parser = SchemaParser::new();
+  let number_json = r#"{"phone_number": 491234568789}"#;
+  let string_json = r#"{"phone_number": "+441234456789"}"#;
+  schema_parser.write(number_json).unwrap();
+  schema_parser.write(string_json).unwrap();
+  println!("{:?}", schema_parser);
+  assert_eq!(schema_parser.fields[0].count, 2);
+  assert_eq!(schema_parser.fields[0].bson_types.len(), 2);
+  assert_eq!(schema_parser.fields[0].types.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
- Array values per field are now handled properly: all values in an array get added to the same `field_type.values` vector. Which means they all stick together. (includes a regression test)
- Nested documents stay nested in `SchemaParser`. Recursion control flow works properly, and if a field has a Document type and that Document type also has a Document type, it gets reflected properly. 
- If a field across documents in a collection show up as different types, different `field_types` for a `field` get added. (includes a regression test)